### PR TITLE
Fixed executable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 
 Change permissions:
 ```sh
-chmod +x /opt/letsencrypt-routeros/letsencrypt-routeros.sh
+chmod +x /opt/letsencrypt-routeros/letsencrypt-mikrotik.sh
 ```
 Generate DSA Key for RouterOS
 


### PR DESCRIPTION
Instruction referenced to letsencrypt-routeros.sh, changed to letsencrypt-microtik.sh which is the actual filename of the executable.