### PR TITLE
Use RSA SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ Change permissions:
 ```sh
 chmod +x /opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```
-Generate DSA Key for RouterOS
+Generate RSA Key for RouterOS
 
 *Make sure to leave the passphrase blank (-N "")*
 
 ```sh
-ssh-keygen -t dsa -f /opt/letsencrypt-routeros/id_dsa -N ""
+ssh-keygen -t rsa -f /opt/letsencrypt-routeros/id_rsa -N ""
 ```
 
-Send Generated DSA Key to RouterOS / Mikrotik
+Send Generated RSA Key to RouterOS / Mikrotik
 ```sh
 source /opt/letsencrypt-routeros/letsencrypt-routeros.settings
-scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_dsa.pub" 
+scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_rsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_rsa.pub" 
 ```
 
 ### Setup RouterOS / Mikrotik side
@@ -67,8 +67,8 @@ scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@
 :put "Enable SSH"
 /ip service enable ssh
 
-:put "Add to the user DSA Public Key"
-/user ssh-keys import user=admin public-key-file=id_dsa.pub
+:put "Add to the user RSA Public Key"
+/user ssh-keys import user=admin public-key-file=id_rsa.pub
 ```
 
 ### CertBot Let's Encrypt

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -5,5 +5,5 @@
 ROUTEROS_USER=admin
 ROUTEROS_HOST=10.0.254.254
 ROUTEROS_SSH_PORT=22
-ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_dsa
+ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_rsa
 DOMAIN=vpnserver.yourdomain.com


### PR DESCRIPTION
DSA SSH keys are deprecated in RouterOS (see https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)#DSA_deprecated) and thus won't work for automated SSH logins without configuration changes on the router.  However, RSA keys work just fine.  These commits edit the README to generate/copy/install RSA keys, and the .settings file to use the RSA key rather than DSA.