### PR TITLE
See newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### How it works:
 * Dedicated Linux renew and push certificates to RouterOS / Mikrotik
 * After CertBot renew your certificates
-* The script connects to RouterOS / Mikrotik using DSA Key (without password or user input)
+* The script connects to RouterOS / Mikrotik using RSA Key (without password or user input)
 * Delete previous certificate files
 * Delete the previous certificate
 * Upload two new files: **Certificate** and **Key**
@@ -35,7 +35,7 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_USER | admin | user with admin rights to connect to RouterOS |
 | ROUTEROS_HOST | 10.0.254.254 | RouterOS\Mikrotik IP |
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
-| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_dsa | Private Key to connecto to RouterOS |
+| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 
 
@@ -43,18 +43,18 @@ Change permissions:
 ```sh
 chmod +x /opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```
-Generate DSA Key for RouterOS
+Generate RSA Key for RouterOS
 
 *Make sure to leave the passphrase blank (-N "")*
 
 ```sh
-ssh-keygen -t dsa -f /opt/letsencrypt-routeros/id_dsa -N ""
+ssh-keygen -t rsa -f /opt/letsencrypt-routeros/id_rsa -N ""
 ```
 
-Send Generated DSA Key to RouterOS / Mikrotik
+Send Generated RSA Key to RouterOS / Mikrotik
 ```sh
 source /opt/letsencrypt-routeros/letsencrypt-routeros.settings
-scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_dsa.pub" 
+scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_rsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_rsa.pub" 
 ```
 
 ### Setup RouterOS / Mikrotik side
@@ -67,8 +67,8 @@ scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@
 :put "Enable SSH"
 /ip service enable ssh
 
-:put "Add to the user DSA Public Key"
-/user ssh-keys import user=admin public-key-file=id_dsa.pub
+:put "Add to the user RSA Public Key"
+/user ssh-keys import user=admin public-key-file=id_rsa.pub
 ```
 
 ### CertBot Let's Encrypt
@@ -92,7 +92,7 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ```
 
 ### Usage of the script
-*To use settings form the settings file:*
+*To use settings from the settings file:*
 ```sh
 ./opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -5,5 +5,5 @@
 ROUTEROS_USER=admin
 ROUTEROS_HOST=10.0.254.254
 ROUTEROS_SSH_PORT=22
-ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_dsa
+ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_rsa
 DOMAIN=vpnserver.yourdomain.com

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -21,8 +21,16 @@ fi
 CERTIFICATE=/etc/letsencrypt/live/$DOMAIN/cert.pem
 KEY=/etc/letsencrypt/live/$DOMAIN/privkey.pem
 
+echo ""
+echo "Updating certificate for $DOMAIN"
+echo "  Using certificate $CERTIFICATE"
+echo "  User private key $KEY"
+
 #Create alias for RouterOS command
 routeros="ssh -i $ROUTEROS_PRIVATE_KEY $ROUTEROS_USER@$ROUTEROS_HOST -p $ROUTEROS_SSH_PORT"
+
+echo ""
+echo "Checking connection to RouterOS"
 
 #Check connection to RouterOS
 $routeros /system resource print
@@ -48,32 +56,60 @@ if [ ! -f $CERTIFICATE ] && [ ! -f $KEY ]; then
         exit 1
 fi
 
-# Remove previous certificate
-$routeros /certificate remove [find name=$DOMAIN.pem_0]
+# Set up variables to remove erros
+DOMAIN_INSTALLED_CERT_FILE=$DOMAIN.pem_0
+DOMAIN_CERT_FILE=$DOMAIN.pem
+DOMAIN_KEY_FILE=$DOMAIN.key
 
+# Remove previous certificate
+echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /certificate remove [find name=$DOMAIN_INSTALLED_CERT_FILE]
+
+echo ""
+echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-$routeros /file remove $DOMAIN.pem > /dev/null
+echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove $DOMAIN_CERT_FILE > /dev/null
 # Upload Certificate to RouterOS
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN.pem"
+echo "  Uploading new domain certificate file to router: $CERTIFICATE"
+scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
 sleep 2
 # Import Certificate file
-$routeros /certificate import file-name=$DOMAIN.pem passphrase=\"\"
+echo "  Importing new certificate file to router certificates"
+$routeros /certificate import file-name=$DOMAIN_CERT_FILE passphrase=\"\"
 # Delete Certificate file after import
-$routeros /file remove $DOMAIN.pem
+echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove $DOMAIN_CERT_FILE
 
+echo ""
+echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
-$routeros /file remove $KEY.key > /dev/null
+echo "  Deleting any old copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove $DOMAIN_KEY_FILE > /dev/null
 # Upload Key to RouterOS
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN.key"
+echo "  Uploading new domain key file to router: $KEY"
+scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
 sleep 2
 # Import Key file
-$routeros /certificate import file-name=$DOMAIN.key passphrase=\"\"
+echo "  Importing new key file to router certificates"
+$routeros /certificate import file-name=$DOMAIN_KEY_FILE passphrase=\"\"
 # Delete Certificate file after import
-$routeros /file remove $DOMAIN.key
+echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove $DOMAIN_KEY_FILE
+
+echo ""
 
 # Setup Certificate to SSTP Server
-$routeros /interface sstp-server server set certificate=$DOMAIN.pem_0
+echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /interface sstp-server server set certificate=$DOMAIN_INSTALLED_CERT_FILE
+
+# Setup Certificate to SSL
+echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /ip service set www-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+
+echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /ip service set api-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
 
 exit 0


### PR DESCRIPTION
This pull request fixes all the places DSA keys are references, as they are now deprecated (also noted in pull request #8 ). It adds other places DSA is mentioned to that pull request.

In addition, it now sets the HTTP and API-SSL service certificates automatically and adds additional debugging information for places where large amounts of domains may be scripted and feedback is needed as to which fails out. Finally, it uses variables for a few of the file names that are repeatedly typed so as to limit the amount of changes that are needed in the future for the end user.