### PR TITLE
Added auto-setting of www-ssl and api-ssl certificates, extra debugging, support for OpenSSH 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
 | ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
+| SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
+| SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
+| SSH_ACCEPTED_ALGORITHMS | ssh-rsa,ssh-dsa | Allows to override SSH option PubkeyAcceptedAlgorithms |
 
 
 Change permissions:
@@ -98,12 +101,12 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ### Usage of the script
 *To use settings from the settings file:*
 ```sh
-./opt/letsencrypt-routeros/letsencrypt-routeros.sh
+/opt/letsencrypt-routeros/letsencrypt-routeros.sh -c letsencrypt-routeros.settings
 ```
 *To use script without settings file:*
 
 ```sh
-./opt/letsencrypt-routeros/letsencrypt-routeros.sh [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]
+/opt/letsencrypt-routeros/letsencrypt-routeros.sh -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]
 ```
 *To use script with CertBot hooks for wildcard domain:*
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_USER | admin | user with admin rights to connect to RouterOS |
 | ROUTEROS_HOST | 10.0.254.254 | RouterOS\Mikrotik IP |
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
-| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
+| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connect to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 | SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
 | SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
@@ -117,7 +117,7 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ```
 
 ---
-### Licence MIT
+### License MIT
 Copyright 2018 Konstantin Gimpel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 | SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
 | SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
-| SSH_ACCEPTED_ALGORITHMS | ssh-rsa,ssh-dsa | Allows to override SSH option PubkeyAcceptedAlgorithms |
 
 
 Change permissions:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **Let's Encrypt certificates for RouterOS / Mikrotik**
 
 *UPD 2018-05-27: Works with wildcard Let's Encrypt Domains*
+
 *UPD 2019-07-11: Works with OpenSSH 7+*
 
 [![Mikrotik](https://i.mt.lv/mtv2/logo.svg)](https://mikrotik.com/)

--- a/README.md
+++ b/README.md
@@ -114,13 +114,6 @@ certbot certonly --preferred-challenges=dns --manual -d *.$DOMAIN --manual-publi
 certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-ip-logging-ok --post-hook /opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```
 
-### Edit Script
-You can easily edit script to execute your commands on RouterOS / Mikrotik after certificates renewal
-Add these strings in the «.sh» file before «exit 0» to have www-ssl and api-ssl works with Let's Encrypt SSL
-```sh
-$routeros /ip service set www-ssl certificate=$DOMAIN.pem_0
-$routeros /ip service set api-ssl certificate=$DOMAIN.pem_0
-```
 ---
 ### Licence MIT
 Copyright 2018 Konstantin Gimpel

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### How it works:
 * Dedicated Linux renew and push certificates to RouterOS / Mikrotik
 * After CertBot renew your certificates
-* The script connects to RouterOS / Mikrotik using DSA Key (without password or user input)
+* The script connects to RouterOS / Mikrotik using RSA Key (without password or user input)
 * Delete previous certificate files
 * Delete the previous certificate
 * Upload two new files: **Certificate** and **Key**
@@ -35,7 +35,7 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_USER | admin | user with admin rights to connect to RouterOS |
 | ROUTEROS_HOST | 10.0.254.254 | RouterOS\Mikrotik IP |
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
-| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_dsa | Private Key to connecto to RouterOS |
+| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 
 
@@ -43,18 +43,18 @@ Change permissions:
 ```sh
 chmod +x /opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```
-Generate DSA Key for RouterOS
+Generate RSA Key for RouterOS
 
 *Make sure to leave the passphrase blank (-N "")*
 
 ```sh
-ssh-keygen -t dsa -f /opt/letsencrypt-routeros/id_dsa -N ""
+ssh-keygen -t rsa -f /opt/letsencrypt-routeros/id_rsa -N ""
 ```
 
-Send Generated DSA Key to RouterOS / Mikrotik
+Send Generated RSA Key to RouterOS / Mikrotik
 ```sh
 source /opt/letsencrypt-routeros/letsencrypt-routeros.settings
-scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_dsa.pub" 
+scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_rsa.pub "$ROUTEROS_USER"@"$ROUTEROS_HOST":"id_rsa.pub" 
 ```
 
 ### Setup RouterOS / Mikrotik side
@@ -67,8 +67,8 @@ scp -P $ROUTEROS_SSH_PORT /opt/letsencrypt-routeros/id_dsa.pub "$ROUTEROS_USER"@
 :put "Enable SSH"
 /ip service enable ssh
 
-:put "Add to the user DSA Public Key"
-/user ssh-keys import user=admin public-key-file=id_dsa.pub
+:put "Add to the user RSA Public Key"
+/user ssh-keys import user=admin public-key-file=id_rsa.pub
 ```
 
 ### CertBot Let's Encrypt
@@ -92,7 +92,7 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ```
 
 ### Usage of the script
-*To use settings form the settings file:*
+*To use settings from the settings file:*
 ```sh
 ./opt/letsencrypt-routeros/letsencrypt-routeros.sh
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **Let's Encrypt certificates for RouterOS / Mikrotik**
 
 *UPD 2018-05-27: Works with wildcard Let's Encrypt Domains*
+*UPD 2019-07-11: Works with OpenSSH 7+*
 
 [![Mikrotik](https://i.mt.lv/mtv2/logo.svg)](https://mikrotik.com/)
 
@@ -15,7 +16,9 @@
 * Upload two new files: **Certificate** and **Key**
 * Import **Certificate** and **Key**
 * Change **SSTP Server Settings** to use new certificate
-* Delete certificate and key files form RouterOS / Mikrotik storage
+* Change **WWW-SSL Service** to use new certificate
+* Change **API-SSL Service** to use new certificate
+* Delete certificate and key files from RouterOS / Mikrotik storage
 
 ### Installation on Ubuntu 16.04
 *Similar way you can use on Debian/CentOS/AMI Linux/Arch/Others*

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -5,5 +5,5 @@
 ROUTEROS_USER=admin
 ROUTEROS_HOST=10.0.254.254
 ROUTEROS_SSH_PORT=22
-ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_dsa
+ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_rsa
 DOMAIN=vpnserver.yourdomain.com

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -7,3 +7,10 @@ ROUTEROS_HOST=10.0.254.254
 ROUTEROS_SSH_PORT=22
 ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_rsa
 DOMAIN=vpnserver.yourdomain.com
+## Uncomment this to specify array of services that will be setup
+## If not specified certificate is installed to (SSTP WWW API)
+#SETUP_SERVICES=(WWW API)
+## Uncomment this to disable StrictHostKeyChecking (default yes)
+#SSH_STRICT_KEY_CHECKING=no
+## Uncomment this to specify PubkeyAcceptedAlgorithms (default ssh-rsa,ssh-dsa)
+#SSH_ACCEPTED_ALGORITHMS=ssh-dsa

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -12,5 +12,3 @@ DOMAIN=vpnserver.yourdomain.com
 #SETUP_SERVICES=(WWW API)
 ## Uncomment this to disable StrictHostKeyChecking (default yes)
 #SSH_STRICT_KEY_CHECKING=no
-## Uncomment this to specify PubkeyAcceptedAlgorithms (default ssh-rsa,ssh-dsa)
-#SSH_ACCEPTED_ALGORITHMS=ssh-dsa

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -47,10 +47,10 @@ echo "  Using certificate ${CERTIFICATE}"
 echo "  User private key ${KEY}"
 
 #Create alias for RouterOS command
-routeros="ssh -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
 
 #Create alias for scp command
-scp="scp -q -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
+scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
 
 echo ""
 echo "Checking connection to RouterOS"

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,56 +1,58 @@
 #!/bin/bash
-#set -x
 
 while getopts 'u:h:p:k:d:c:' OPTION; do
 	case "$OPTION" in
-		u)
-			ROUTEROS_USER=${OPTARG}
-			;;
-		h)
-			ROUTEROS_HOST=${OPTARG}
-			;;
-		p)
-			ROUTEROS_SSH_PORT=${OPTARG}
-			;;
-		k)
-			ROUTEROS_PRIVATE_KEY=${OPTARG}
-			;;
-		d)
-			DOMAIN=${OPTARG}
-			;;
-		c)
-			CONFIG=${OPTARG}
-			;;
-		esac
+	u)
+		ROUTEROS_USER=$OPTARG
+		;;
+	h)
+		ROUTEROS_HOST=$OPTARG
+		;;
+	p)
+		ROUTEROS_SSH_PORT=$OPTARG
+		;;
+	k)
+		ROUTEROS_PRIVATE_KEY=$OPTARG
+		;;
+	d)
+		DOMAIN=$OPTARG
+		;;
+	c)
+		CONFIG=$OPTARG
+		;;
+	*)
+		echo "Unknown option '$OPTION'"
+		;;
+	esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND - 1))"
 
-if [[ -n ${CONFIG} ]]; then
-	source $CONFIG
-elif [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
-        echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+if [[ -n $CONFIG ]]; then
+	source "$CONFIG"
+elif [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
+	echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
 	exit 1
 fi
 
-if [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
-        echo "Check the config file ${CONFIG_FILE} or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
-        echo "Please avoid spaces"
-        exit 1
+if [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
+	echo "Check the config file $CONFIG_FILE or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+	echo "Please avoid spaces"
+	exit 1
 fi
 
 CERTIFICATE=/etc/letsencrypt/live/${DOMAIN}/cert.pem
 KEY=/etc/letsencrypt/live/${DOMAIN}/privkey.pem
 
 echo ""
-echo "Updating certificate for ${DOMAIN}"
-echo "  Using certificate ${CERTIFICATE}"
-echo "  User private key ${KEY}"
+echo "Updating certificate for $DOMAIN"
+echo "  Using certificate $CERTIFICATE"
+echo "  User private key $KEY"
 
 #Create alias for RouterOS command
-routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i $ROUTEROS_PRIVATE_KEY ${ROUTEROS_USER}@${ROUTEROS_HOST} -p $ROUTEROS_SSH_PORT"
 
 #Create alias for scp command
-scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
+scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P $ROUTEROS_SSH_PORT -i $ROUTEROS_PRIVATE_KEY"
 
 echo ""
 echo "Checking connection to RouterOS"
@@ -60,23 +62,23 @@ $routeros /system resource print
 RESULT=$?
 
 if [[ ! ${RESULT} == 0 ]]; then
-        echo -e "\nError in: $routeros"
-        echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
-        exit 1
+	echo -e "\nError in: $routeros"
+	echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
+	exit 1
 else
-        echo -e "\nConnection to RouterOS Successful!\n" 
+	echo -e "\nConnection to RouterOS Successful!\n"
 fi
 
-if [ ! -f ${CERTIFICATE} ] && [ ! -f ${KEY} ]; then
-        echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
-        echo -e "Please use CertBot Let'sEncrypt:"
-        echo "============================"
-        echo "certbot certonly --preferred-challenges=dns --manual -d ${DOMAIN} --manual-public-ip-logging-ok"
-        echo "or (for wildcard certificate):"
-        echo "certbot certonly --preferred-challenges=dns --manual -d *.${DOMAIN} --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
-        echo "==========================="
-        echo -e "and follow instructions from CertBot\n"
-        exit 1
+if [ ! -f "$CERTIFICATE" ] && [ ! -f "$KEY" ]; then
+	echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
+	echo -e "Please use CertBot Let'sEncrypt:"
+	echo "============================"
+	echo "certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-ip-logging-ok"
+	echo "or (for wildcard certificate):"
+	echo "certbot certonly --preferred-challenges=dns --manual -d *.$DOMAIN --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
+	echo "==========================="
+	echo -e "and follow instructions from CertBot\n"
+	exit 1
 fi
 
 # Set up variables to remove errors
@@ -85,61 +87,61 @@ DOMAIN_CERT_FILE=${DOMAIN}.pem
 DOMAIN_KEY_FILE=${DOMAIN}.key
 
 # Remove previous certificate
-echo "Removing old certificate from installed certificates: ${DOMAIN_INSTALLED_CERT_FILE}"
-$routeros /certificate remove [find name=${DOMAIN_INSTALLED_CERT_FILE}]
+echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /certificate remove [find name="$DOMAIN_INSTALLED_CERT_FILE"]
 
 echo ""
 echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
-$routeros /file remove ${DOMAIN_CERT_FILE} > /dev/null
+echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove "$DOMAIN_CERT_FILE" >/dev/null
 # Upload Certificate to RouterOS
-echo "  Uploading new domain certificate file to router: ${CERTIFICATE}"
-$scp "${CERTIFICATE}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_CERT_FILE}"
+echo "  Uploading new domain certificate file to router: $CERTIFICATE"
+$scp "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
 sleep 2
 # Import Certificate file
 echo "  Importing new certificate file to router certificates"
-$routeros /certificate import file-name=${DOMAIN_CERT_FILE} passphrase=\"\"
+$routeros /certificate import file-name="$DOMAIN_CERT_FILE" passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
-$routeros /file remove ${DOMAIN_CERT_FILE}
+echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove "$DOMAIN_CERT_FILE"
 
 echo ""
 echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
 echo "  Deleting any old copy of key file from disk: ${DOMAIN_KEY_FILE}"
-$routeros /file remove ${DOMAIN_KEY_FILE} > /dev/null
+$routeros /file remove "$DOMAIN_KEY_FILE" >/dev/null
 # Upload Key to RouterOS
-echo "  Uploading new domain key file to router: ${KEY}"
-$scp "${KEY}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_KEY_FILE}"
+echo "  Uploading new domain key file to router: $KEY"
+$scp "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
 sleep 2
 # Import Key file
 echo "  Importing new key file to router certificates"
-$routeros /certificate import file-name=${DOMAIN_KEY_FILE} passphrase=\"\"
+$routeros /certificate import file-name="$DOMAIN_KEY_FILE" passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of key file from disk: ${DOMAIN_KEY_FILE}"
-$routeros /file remove ${DOMAIN_KEY_FILE}
+echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove "$DOMAIN_KEY_FILE"
 
 echo ""
 
 # Setup Certificate to SSTP Service
 if [[ "${SETUP_SERVICES[*]:-SSTP}" =~ "SSTP" ]]; then
-	echo "Updating SSTP Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /interface sstp-server server set certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /interface sstp-server server set certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 # Setup Certificate to WWW Service
 if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
-	echo "Updating HTTPS Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /ip service set www-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /ip service set www-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 # Setup Certificat to API Service
 if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
-	echo "Updating API SSL Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /ip service set api-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /ip service set api-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 exit 0

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,33 +1,56 @@
 #!/bin/bash
-CONFIG_FILE=letsencrypt-routeros.settings
+#set -x
 
-if [[ -z $1 ]] || [[ -z $2 ]] || [[ -z $3 ]] || [[ -z $4 ]] || [[ -z $5 ]]; then
-        echo -e "Usage: $0 or $0 [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]\n"
-        source $CONFIG_FILE
-else
-        ROUTEROS_USER=$1
-        ROUTEROS_HOST=$2
-        ROUTEROS_SSH_PORT=$3
-        ROUTEROS_PRIVATE_KEY=$4
-        DOMAIN=$5
+while getopts 'u:h:p:k:d:c:' OPTION; do
+	case "$OPTION" in
+		u)
+			ROUTEROS_USER=${OPTARG}
+			;;
+		h)
+			ROUTEROS_HOST=${OPTARG}
+			;;
+		p)
+			ROUTEROS_SSH_PORT=${OPTARG}
+			;;
+		k)
+			ROUTEROS_PRIVATE_KEY=${OPTARG}
+			;;
+		d)
+			DOMAIN=${OPTARG}
+			;;
+		c)
+			CONFIG=${OPTARG}
+			;;
+		esac
+done
+shift "$(($OPTIND -1))"
+
+if [[ -n ${CONFIG} ]]; then
+	source $CONFIG
+elif [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
+        echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+	exit 1
 fi
 
-if [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
-        echo "Check the config file $CONFIG_FILE or start with params: $0 [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]"
+if [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
+        echo "Check the config file ${CONFIG_FILE} or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
         echo "Please avoid spaces"
         exit 1
 fi
 
-CERTIFICATE=/etc/letsencrypt/live/$DOMAIN/cert.pem
-KEY=/etc/letsencrypt/live/$DOMAIN/privkey.pem
+CERTIFICATE=/etc/letsencrypt/live/${DOMAIN}/cert.pem
+KEY=/etc/letsencrypt/live/${DOMAIN}/privkey.pem
 
 echo ""
-echo "Updating certificate for $DOMAIN"
-echo "  Using certificate $CERTIFICATE"
-echo "  User private key $KEY"
+echo "Updating certificate for ${DOMAIN}"
+echo "  Using certificate ${CERTIFICATE}"
+echo "  User private key ${KEY}"
 
 #Create alias for RouterOS command
-routeros="ssh -i $ROUTEROS_PRIVATE_KEY $ROUTEROS_USER@$ROUTEROS_HOST -p $ROUTEROS_SSH_PORT"
+routeros="ssh -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+
+#Create alias for scp command
+scp="scp -q -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
 
 echo ""
 echo "Checking connection to RouterOS"
@@ -36,7 +59,7 @@ echo "Checking connection to RouterOS"
 $routeros /system resource print
 RESULT=$?
 
-if [[ ! $RESULT == 0 ]]; then
+if [[ ! ${RESULT} == 0 ]]; then
         echo -e "\nError in: $routeros"
         echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
         exit 1
@@ -44,72 +67,79 @@ else
         echo -e "\nConnection to RouterOS Successful!\n" 
 fi
 
-if [ ! -f $CERTIFICATE ] && [ ! -f $KEY ]; then
-        echo -e "\nFile(s) not found:\n$CERTIFICATE\n$KEY\n"
+if [ ! -f ${CERTIFICATE} ] && [ ! -f ${KEY} ]; then
+        echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
         echo -e "Please use CertBot Let'sEncrypt:"
         echo "============================"
-        echo "certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-ip-logging-ok"
+        echo "certbot certonly --preferred-challenges=dns --manual -d ${DOMAIN} --manual-public-ip-logging-ok"
         echo "or (for wildcard certificate):"
-        echo "certbot certonly --preferred-challenges=dns --manual -d *.$DOMAIN --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
+        echo "certbot certonly --preferred-challenges=dns --manual -d *.${DOMAIN} --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
         echo "==========================="
         echo -e "and follow instructions from CertBot\n"
         exit 1
 fi
 
 # Set up variables to remove errors
-DOMAIN_INSTALLED_CERT_FILE=$DOMAIN.pem_0
-DOMAIN_CERT_FILE=$DOMAIN.pem
-DOMAIN_KEY_FILE=$DOMAIN.key
+DOMAIN_INSTALLED_CERT_FILE=${DOMAIN}.pem_0
+DOMAIN_CERT_FILE=${DOMAIN}.pem
+DOMAIN_KEY_FILE=${DOMAIN}.key
 
 # Remove previous certificate
-echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /certificate remove [find name=$DOMAIN_INSTALLED_CERT_FILE]
+echo "Removing old certificate from installed certificates: ${DOMAIN_INSTALLED_CERT_FILE}"
+$routeros /certificate remove [find name=${DOMAIN_INSTALLED_CERT_FILE}]
 
 echo ""
 echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
-$routeros /file remove $DOMAIN_CERT_FILE > /dev/null
+echo "  Deleting any old copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
+$routeros /file remove ${DOMAIN_CERT_FILE} > /dev/null
 # Upload Certificate to RouterOS
-echo "  Uploading new domain certificate file to router: $CERTIFICATE"
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
+echo "  Uploading new domain certificate file to router: ${CERTIFICATE}"
+$scp "${CERTIFICATE}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_CERT_FILE}"
 sleep 2
 # Import Certificate file
 echo "  Importing new certificate file to router certificates"
-$routeros /certificate import file-name=$DOMAIN_CERT_FILE passphrase=\"\"
+$routeros /certificate import file-name=${DOMAIN_CERT_FILE} passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
-$routeros /file remove $DOMAIN_CERT_FILE
+echo "  Deleting any new copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
+$routeros /file remove ${DOMAIN_CERT_FILE}
 
 echo ""
 echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of key file from disk: $DOMAIN_KEY_FILE"
-$routeros /file remove $DOMAIN_KEY_FILE > /dev/null
+echo "  Deleting any old copy of key file from disk: ${DOMAIN_KEY_FILE}"
+$routeros /file remove ${DOMAIN_KEY_FILE} > /dev/null
 # Upload Key to RouterOS
-echo "  Uploading new domain key file to router: $KEY"
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
+echo "  Uploading new domain key file to router: ${KEY}"
+$scp "${KEY}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_KEY_FILE}"
 sleep 2
 # Import Key file
 echo "  Importing new key file to router certificates"
-$routeros /certificate import file-name=$DOMAIN_KEY_FILE passphrase=\"\"
+$routeros /certificate import file-name=${DOMAIN_KEY_FILE} passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
-$routeros /file remove $DOMAIN_KEY_FILE
+echo "  Deleting any new copy of key file from disk: ${DOMAIN_KEY_FILE}"
+$routeros /file remove ${DOMAIN_KEY_FILE}
 
 echo ""
 
-# Setup Certificate to SSTP Server
-echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /interface sstp-server server set certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificate to SSTP Service
+if [[ "${SETUP_SERVICES[*]:-SSTP}" =~ "SSTP" ]]; then
+	echo "Updating SSTP Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /interface sstp-server server set certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
-# Setup Certificate to SSL
-echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /ip service set www-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificate to WWW Service
+if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
+	echo "Updating HTTPS Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /ip service set www-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
-echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /ip service set api-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificat to API Service
+if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
+	echo "Updating API SSL Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /ip service set api-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
 exit 0

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts 'u:h:p:k:d:c:' OPTION; do
+while getopts 'u:h:p:k:d:f:' OPTION; do
 	case "$OPTION" in
 	u)
 		ROUTEROS_USER=$OPTARG
@@ -17,7 +17,7 @@ while getopts 'u:h:p:k:d:c:' OPTION; do
 	d)
 		DOMAIN=$OPTARG
 		;;
-	c)
+	f)
 		CONFIG=$OPTARG
 		;;
 	*)
@@ -138,7 +138,7 @@ if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
 	$routeros /ip service set www-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
-# Setup Certificat to API Service
+# Setup Certificate to API Service
 if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
 	echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
 	$routeros /ip service set api-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -21,8 +21,16 @@ fi
 CERTIFICATE=/etc/letsencrypt/live/$DOMAIN/cert.pem
 KEY=/etc/letsencrypt/live/$DOMAIN/privkey.pem
 
+echo ""
+echo "Updating certificate for $DOMAIN"
+echo "  Using certificate $CERTIFICATE"
+echo "  User private key $KEY"
+
 #Create alias for RouterOS command
 routeros="ssh -i $ROUTEROS_PRIVATE_KEY $ROUTEROS_USER@$ROUTEROS_HOST -p $ROUTEROS_SSH_PORT"
+
+echo ""
+echo "Checking connection to RouterOS"
 
 #Check connection to RouterOS
 $routeros /system resource print
@@ -48,32 +56,60 @@ if [ ! -f $CERTIFICATE ] && [ ! -f $KEY ]; then
         exit 1
 fi
 
-# Remove previous certificate
-$routeros /certificate remove [find name=$DOMAIN.pem_0]
+# Set up variables to remove erros
+DOMAIN_INSTALLED_CERT_FILE=$DOMAIN.pem_0
+DOMAIN_CERT_FILE=$DOMAIN.pem
+DOMAIN_KEY_FILE=$DOMAIN.key
 
+# Remove previous certificate
+echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /certificate remove [find name=$DOMAIN_INSTALLED_CERT_FILE]
+
+echo ""
+echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-$routeros /file remove $DOMAIN.pem > /dev/null
+echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove $DOMAIN_CERT_FILE > /dev/null
 # Upload Certificate to RouterOS
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN.pem"
+echo "  Uploading new domain certificate file to router: $CERTIFICATE"
+scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
 sleep 2
 # Import Certificate file
-$routeros /certificate import file-name=$DOMAIN.pem passphrase=\"\"
+echo "  Importing new certificate file to router certificates"
+$routeros /certificate import file-name=$DOMAIN_CERT_FILE passphrase=\"\"
 # Delete Certificate file after import
-$routeros /file remove $DOMAIN.pem
+echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove $DOMAIN_CERT_FILE
 
+echo ""
+echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
-$routeros /file remove $KEY.key > /dev/null
+echo "  Deleting any old copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove $DOMAIN_KEY_FILE > /dev/null
 # Upload Key to RouterOS
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN.key"
+echo "  Uploading new domain key file to router: $KEY"
+scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
 sleep 2
 # Import Key file
-$routeros /certificate import file-name=$DOMAIN.key passphrase=\"\"
+echo "  Importing new key file to router certificates"
+$routeros /certificate import file-name=$DOMAIN_KEY_FILE passphrase=\"\"
 # Delete Certificate file after import
-$routeros /file remove $DOMAIN.key
+echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove $DOMAIN_KEY_FILE
+
+echo ""
 
 # Setup Certificate to SSTP Server
-$routeros /interface sstp-server server set certificate=$DOMAIN.pem_0
+echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /interface sstp-server server set certificate=$DOMAIN_INSTALLED_CERT_FILE
+
+# Setup Certificate to SSL
+echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /ip service set www-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+
+echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /ip service set api-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
 
 exit 0

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -56,7 +56,7 @@ if [ ! -f $CERTIFICATE ] && [ ! -f $KEY ]; then
         exit 1
 fi
 
-# Set up variables to remove erros
+# Set up variables to remove errors
 DOMAIN_INSTALLED_CERT_FILE=$DOMAIN.pem_0
 DOMAIN_CERT_FILE=$DOMAIN.pem
 DOMAIN_KEY_FILE=$DOMAIN.key


### PR DESCRIPTION
This pull request is similar to pull request #8 but more comprehensive in the places it fixes "DSA" to be "RSA" in the code examples and commentary. OpenSSH 7+ doesn't allow users to use DSA without manually approving it in their SSH config file and most users will have errors (see the open issues for reference). The README is updated with this fact and it is flagged at the top as a major update.

This pull request also automatically sets the www-ssl and api-ssl certificates to be the newly uploaded one. The README is updated with this fact.

This pull request also changes a lot of the references to files to be variables that are set once. This allows greater flexibility to the end user and lowers the possibility of typos later during changes.